### PR TITLE
Add Swift Bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 /bindings/rust
 /Cargo.toml
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterTOML",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterTOML", targets: ["TreeSitterTOML"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterTOML",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "corpus",
+                    "examples",
+                    "grammar.js",
+                    "LICENSE",
+                    "package.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.c",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterTOML/toml.h
+++ b/bindings/swift/TreeSitterTOML/toml.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_TOML_H_
+#define TREE_SITTER_TOML_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_toml();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_TOML_H_


### PR DESCRIPTION
The Swift Package Manager can build C and C++ sources and use headers to expose functions to Swift.

These additions and modifications allow the SPM to use the TOML Tree Sitter and for use in Swift apps.